### PR TITLE
Add state 18 - room cleaning

### DIFF
--- a/lib/miio-roborock-vocabulary.js
+++ b/lib/miio-roborock-vocabulary.js
@@ -85,6 +85,7 @@ class MiioRoborockVocabulary {
             15:'docking',
             16:'coordinates',
             17:'zone-cleaning',
+            18:'room-cleaning',
             100:'full',
 
             101: 'quiet',


### PR DESCRIPTION
Adds state 18 `room-cleaning`. On the S5 this state is used when a room is being cleaned. This is cosmetic however if you want to trigger off the status it's now possible. I had a guess 18 was room cleaning then went look on GitHub for a patched miio library and found one under the homebridge project[1].

Tested on Roborock S5 v.3.5.7_002008.

[1] https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/blob/d77a0679d09338908084d4ee74e0aa7668fe9757/miio/lib/devices/vacuum.js#L82

As a side note [1] seems to be the new home for the miio library, lots of fixes and patches have been applied.

Before:
![image](https://user-images.githubusercontent.com/5630595/85220111-5ea8dc80-b3ec-11ea-84c4-81cf61ed24ec.png)

After:
![image](https://user-images.githubusercontent.com/5630595/85220122-6ec0bc00-b3ec-11ea-94c6-9a3616d2bf65.png)

