### PR TITLE
Catch uncaught promises and retry connecting on failure

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,0 +1,20 @@
+const wait = time => new Promise((resolve) => setTimeout(resolve, time));
+const retryOperation = (operation,  operationName = 'Operation', retries = 1e4, delayInMs = 5000) => new Promise((resolve, reject) => {
+    return operation()
+        .then(resolve)
+        .catch((reason) => {
+            console.log(`${operationName} failed!`, reason);
+
+            if (retries > 0) {
+                console.log(`Retrying ${operationName} in ${delayInMs}ms ...`);
+
+                return wait(delayInMs)
+                    .then(retryOperation.bind(null, operation, operationName, retries - 1, delayInMs))
+                    .then(resolve)
+                    .catch(reject);
+            }
+            return reject(reason);
+        });
+});
+
+module.exports = retryOperation;


### PR DESCRIPTION
## The problem
When `node-red` starts up while the Miio Roborock is not connected to the network yet, it fails to connect to it even if it comes online after some time. This is what can be read from the `node-red` logs:
```
31 Dec 16:17:24 - [warn] [miio-roborock-server:Miio server] Miio Roborock Error: send ENETUNREACH 192.168.1.64:54321
(node:342) UnhandledPromiseRejectionWarning: Error: send ENETUNREACH 192.168.1.64:54321
    at SendWrap.afterSend [as oncomplete] (dgram.js:467:11)
(node:342) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:342) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

## The solution
* Catching all the uncaught promises
* Retrying retrieving connection by using a function `retryOperation`, which retries a promise if it fails